### PR TITLE
데이터 블록 순회 로직 일반화를 제외한 리팩토링

### DIFF
--- a/hodo.h
+++ b/hodo.h
@@ -12,11 +12,17 @@
 #ifndef __HODO_H__
 #define __HODO_H__
 
-#define HODO_MAX_NAME_LEN   16
-#define HODO_MAX_INODE      (1 << 16)
+#define HODO_MAX_NAME_LEN       16
+#define HODO_MAX_INODE          (1 << 16)
+#define HODO_DATABLOCK_SIZE     4096
+#define HODO_SECTOR_SIZE        512
+#define HODO_DATA_START         4
 
-#define HODO_TYPE_REG       0            
-#define HODO_TYPE_DIR       1
+#define HODO_TYPE_REG           0            
+#define HODO_TYPE_DIR           1
+
+#define END_READ                0
+#define NOTHING_FOUND           0
 
 #define ZONEFS_TRACE() pr_info("zonefs: >>> %s called\n", __func__)
 


### PR DESCRIPTION
데이터 블록 순회 로직 일반화를 위해선 함수 포인터를 이용할 것이므로, 함수들의 포맷이 상당히 변할 것 같아서 다른 리팩토링을 우선 커밋함.



[논의 사항 외 추가로 수행한 공동 영역 리팩토링]
-섹터 단위 상수 추가 및 적용
define HODO_SECTOR_SIZE        512



[논의 사항 대로 수행한 공동 영역 리팩토링]
-데이터 블록 크기 상수 추가 및 적용
define HODO_DATABLOCK_SIZE     4096
-데이터 블록 내 데이터 영역 시작 인덱스 상수 추가 및 적용
define HODO_DATA_START         4



[개인 영역 리팩토링]
-아이노드의 간접적인 블럭 순회 로직의 단축
struct hodo_block_pos indirect_block_pos[3] = {
	parent_hodo_inode->single_indirect,
	parent_hodo_inode->double_indirect,
	parent_hodo_inode->triple_indirect
};

for(int i = 0; i < 3; i++){
	//각각의 간접적인 블럭들에 수행할 로직
}

-불필요한 pr_print(..) 삭제

-동적 공간 해제 위치 통일(kfree(..))

-find_inode_num(..)과 read_all_dirent(..)들을 위한 리턴 상수 선언 및 적용
define END_READ                0
define NOTHING_FOUND           0

-불필요한 구조체 초기화 문장 제거

-ctx->pos과 dirent_count의 의미를 개수영역으로 통일
ctx->pos	: 이번 ls 명령어 처리를 위해 읽은 디렉토리 엔트리 개수
dirent_count	: 이번 readdir(..) 호출에서 읽은 디렉토리 엔트리 개수

-유효성 판단 등 단순 함수 3개 추가
bool is_block_pos_valid(struct hodo_block_pos block_pos); bool is_directblock(struct hodo_datablock *datablock); bool hodo_dir_emit(struct dir_context *ctx, struct hodo_dirent *temp_dirent>

-hodo_readdir(..)아래에 hodo_sub_readdir(..)추가
static int hodo_sub_readdir(struct file *file, struct dir_context *ctx);

-read_all_dirents(..)에서 불필요한 file 매개변수 삭제