### PR TITLE
rm, rmdir 기능 구현 완료

### DIFF
--- a/hodo.c
+++ b/hodo.c
@@ -126,7 +126,7 @@ void hodo_init(void) {
         // root inode를 wp에 쓰기
         mapping_info.mapping_table[root_inode.i_ino - mapping_info.starting_ino].zone_id = mapping_info.wp.zone_id; 
         mapping_info.mapping_table[root_inode.i_ino - mapping_info.starting_ino].offset = mapping_info.wp.offset;
-        hodo_write_struct((char*)&root_inode, sizeof(root_inode), NULL);
+        hodo_write_struct(&root_inode, sizeof(root_inode), NULL);
     }
 }
 
@@ -326,7 +326,7 @@ static int hodo_create(struct mnt_idmap *idmap, struct inode *dir, struct dentry
     // BUG: zone에 걸친 write가 발생할 시, mapping table 관계가 내부에서 변해야 됨
     mapping_info.mapping_table[hinode.i_ino - mapping_info.starting_ino].zone_id = mapping_info.wp.zone_id; 
     mapping_info.mapping_table[hinode.i_ino - mapping_info.starting_ino].offset = mapping_info.wp.offset;
-    hodo_write_struct((char*)&hinode, sizeof(struct hodo_inode), NULL);
+    hodo_write_struct(&hinode, sizeof(struct hodo_inode), NULL);
     // 여기까지 hinode 초기화: 함수로 리팩터링
 
     add_dirent(dir, &hinode);
@@ -351,16 +351,25 @@ static int hodo_create(struct mnt_idmap *idmap, struct inode *dir, struct dentry
 int hodo_unlink(struct inode *dir,struct dentry *dentry) {
     const char *target_name = dentry->d_name.name;
     const char *parent_name = dentry->d_parent->d_name.name;
+
+    struct timespec64 now;
+    now = current_time(dir);
+    inode_set_ctime_to_ts(dir, now);
+    inode_set_atime_to_ts(dir, now);
+    inode_set_mtime_to_ts(dir, now);
+
     pr_info("zonefs: unlink parameters, parent name: %s, target name: %s\n", parent_name, target_name); 
 
     //루트 디렉토리는 i_ino와 무관하게 매핑 테이블의 0번째 인덱스에 위치하므로, 수동으로 인덱스를 결정한다
     uint64_t parent_mapping_index;
     uint64_t target_mapping_index;
-    if (dir != dentry->d_sb->s_root->d_inode) {
+    if (dir == dentry->d_sb->s_root->d_inode) {
+        pr_info("zonefs: unlink in root directory\n"); 
         parent_mapping_index = 0;
         target_mapping_index = dentry->d_inode->i_ino - mapping_info.starting_ino;
     }
     else {
+        pr_info("zonefs: unlink in non-root directory\n"); 
         parent_mapping_index = dir->i_ino - mapping_info.starting_ino;
         target_mapping_index = dentry->d_inode->i_ino - mapping_info.starting_ino;
     }
@@ -373,27 +382,31 @@ int hodo_unlink(struct inode *dir,struct dentry *dentry) {
     struct hodo_block_pos target_inode_pos;
 
     target_inode_pos = mapping_info.mapping_table[target_mapping_index];
-    hodo_read_struct(target_inode_pos, (char*)&target_inode, sizeof(struct hodo_inode));
+    hodo_read_struct(target_inode_pos, &target_inode, sizeof(struct hodo_inode));
     
     target_inode.i_nlink = 0;
     
-    hodo_write_struct((char*)&target_inode, sizeof(struct hodo_inode), NULL);
+    hodo_write_struct(&target_inode, sizeof(struct hodo_inode), NULL);
 
     //부모 디렉토리 hodo_inode가 가리키는 직간접적인 데이터블럭에서 삭제 파일의 hodo_dirent를 삭제하고 hodo_inode까지 새로 쓰기
     struct hodo_inode parent_inode;
     struct hodo_block_pos parent_inode_pos;
 
     parent_inode_pos = mapping_info.mapping_table[parent_mapping_index];
-    hodo_read_struct(parent_inode_pos, (char*)&parent_inode, sizeof(struct hodo_inode));
+    hodo_read_struct(parent_inode_pos, &parent_inode, sizeof(struct hodo_inode));
     
     struct hodo_block_pos inode_written_pos;
-    remove_dirent(&parent_inode, target_name, &inode_written_pos);
+    remove_dirent(&parent_inode, dir, target_name, &inode_written_pos);
     
     mapping_info.mapping_table[parent_mapping_index].zone_id = inode_written_pos.zone_id;
-    mapping_info.mapping_table[parent_mapping_index].zone_id = inode_written_pos.offset;
+    mapping_info.mapping_table[parent_mapping_index].offset = inode_written_pos.offset;
+
+    //자식 파일이 삭제되었으므로 부모 디렉토리의 VFS 아이노드의 'i_size'을 감소시킨다
+    dir->i_size--;
 
     //VFS 덴트리 캐시 드랍하기
     d_drop(dentry);
+    d_add(dentry, NULL);
     return 0;
 }
 
@@ -439,7 +452,7 @@ static int hodo_mkdir(struct mnt_idmap *idmap, struct inode *dir, struct dentry 
     // BUG: zone에 걸친 write가 발생할 시, mapping table 관계가 내부에서 변해야 됨
     mapping_info.mapping_table[hinode.i_ino - mapping_info.starting_ino].zone_id = mapping_info.wp.zone_id; 
     mapping_info.mapping_table[hinode.i_ino - mapping_info.starting_ino].offset = mapping_info.wp.offset;
-    hodo_write_struct((char*)&hinode, sizeof(struct hodo_inode), NULL);
+    hodo_write_struct(&hinode, sizeof(struct hodo_inode), NULL);
     // 여기까지 hinode 초기화: 함수로 리팩터링
 
     add_dirent(dir, &hinode);
@@ -546,6 +559,12 @@ static struct dentry *hodo_sub_lookup(struct inode* dir, struct dentry* dentry, 
     const char *name = dentry->d_name.name;
     const char *parent = dentry->d_parent->d_name.name;
 
+    struct timespec64 now;
+    now = current_time(dir);
+    inode_set_ctime_to_ts(dir, now);
+    inode_set_atime_to_ts(dir, now);
+    inode_set_mtime_to_ts(dir, now);
+
     //부모 디렉토리의 hodo 아이노드를 읽어온다
     //루트 노드의 hodo 아이노드 상의 번호는 vfs 아이노드 상의 번호와 달리 0번이니 조작한다 
     uint64_t parent_hodo_inode_number = dir->i_ino;
@@ -557,7 +576,7 @@ static struct dentry *hodo_sub_lookup(struct inode* dir, struct dentry* dentry, 
         parent_hodo_inode_pos = mapping_info.mapping_table[parent_hodo_inode_number - mapping_info.starting_ino];
 
     struct hodo_inode parent_hodo_inode;
-    hodo_read_struct(parent_hodo_inode_pos, (char*)&parent_hodo_inode, sizeof(struct hodo_inode));
+    hodo_read_struct(parent_hodo_inode_pos, &parent_hodo_inode, sizeof(struct hodo_inode));
 
     //찾고자 하는 이름을 가진 hodo 아이노드를 읽어온다
     //해당 이름의 아이노드가 저장장치에 없다면, 그냥 없다고 보고하자
@@ -571,7 +590,7 @@ static struct dentry *hodo_sub_lookup(struct inode* dir, struct dentry* dentry, 
     pr_info("zonefs: target hodo inode number: %d\n", target_hodo_inode_number);
     struct hodo_block_pos target_hodo_inode_pos = mapping_info.mapping_table[target_hodo_inode_number - mapping_info.starting_ino];
     struct hodo_inode target_hodo_inode = { 0, };
-    hodo_read_struct(target_hodo_inode_pos, (char*)&target_hodo_inode, sizeof(struct hodo_inode));
+    hodo_read_struct(target_hodo_inode_pos, &target_hodo_inode, sizeof(struct hodo_inode));
 
     //찾던 이름의 hodo 아이노드 정보를 통해 VFS 아이노드를 구성하자
     struct inode *vfs_inode = new_inode(dir->i_sb);
@@ -601,6 +620,12 @@ static int hodo_sub_readdir(struct file *file, struct dir_context *ctx) {
     struct inode *inode = file_inode(file);
     struct dentry *dentry = file->f_path.dentry;
     const char *name = dentry->d_name.name;
+
+    struct timespec64 now;
+    now = current_time(inode);
+    inode_set_ctime_to_ts(inode, now);
+    inode_set_atime_to_ts(inode, now);
+    inode_set_mtime_to_ts(inode, now);
 
     //(inode->i_size 관리 규정이 확실해지면 기능 활성화하기)
     //ctx->pos는 지금까지 읽은 dirent('.', '..', 'hodo_dirent')의 개수를 나타낸다.
@@ -639,7 +664,7 @@ static int hodo_sub_readdir(struct file *file, struct dir_context *ctx) {
     //디렉토리의 hodo 아이노드를 저장장치로부터 읽어온다
     struct hodo_block_pos dir_hodo_inode_pos = mapping_info.mapping_table[dir_hodo_mapping_index];
     struct hodo_inode dir_hodo_inode = { 0, };
-    hodo_read_struct(dir_hodo_inode_pos, (char*)&dir_hodo_inode, sizeof(struct hodo_inode));
+    hodo_read_struct(dir_hodo_inode_pos, &dir_hodo_inode, sizeof(struct hodo_inode));
 
     //디렉토리 hodo 아이노드가 직간접적으로 가리키는 블럭 안의 덴트리들을 모조리 읽는다
     return read_all_dirents(&dir_hodo_inode, ctx, &dirent_count);

--- a/hodo.h
+++ b/hodo.h
@@ -23,6 +23,7 @@
 
 #define END_READ                0
 #define NOTHING_FOUND           0
+#define EMPTY_CHECKED           1
 
 #define ZONEFS_TRACE() pr_info("zonefs: >>> %s called\n", __func__)
 

--- a/trans.c
+++ b/trans.c
@@ -13,9 +13,15 @@
 #include "zonefs.h"
 #include "hodo.h"
 #include "trans.h"
+/*-------------------------------------------------------------static 함수 선언-------------------------------------------------------------------------------*/
+static bool hodo_dir_emit(struct dir_context *ctx, struct hodo_dirent *temp_dirent);
+static void hodo_set_bitmap(int i, int j);
+static void hodo_unset_bitmap(int i, int j);
 
-
+/*-------------------------------------------------------------lookup용 함수----------------------------------------------------------------------------------*/
 uint64_t find_inode_number(struct hodo_inode *dir_hodo_inode, const char *target_name) {
+    ZONEFS_TRACE();
+
     uint64_t result;
     struct hodo_datablock *buf_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
 
@@ -71,6 +77,8 @@ uint64_t find_inode_number_from_direct_block(
     struct hodo_datablock* direct_block,
     const char *target_name
 ) {
+    ZONEFS_TRACE();
+
     for (int j = HODO_DATA_START; j < HODO_DATABLOCK_SIZE - sizeof(struct hodo_dirent); j += sizeof(struct hodo_dirent)) {
         struct hodo_dirent temp_dirent;
         memcpy(&temp_dirent, (void*)direct_block + j, sizeof(struct hodo_dirent));
@@ -86,6 +94,8 @@ uint64_t find_inode_number_from_indirect_block(
     struct hodo_datablock *indirect_block,
     const char *target_name
 ) {
+    ZONEFS_TRACE();
+
     struct hodo_block_pos temp_block_pos;
     struct hodo_datablock *temp_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
 
@@ -120,12 +130,14 @@ uint64_t find_inode_number_from_indirect_block(
     return NOTHING_FOUND;
 }
 
+/*-------------------------------------------------------------readdir용 함수-------------------------------------------------------------------------------*/
 int read_all_dirents(
     struct hodo_inode *dir_hodo_inode, 
     struct dir_context *ctx, 
     uint64_t *dirent_count
 ) {
     ZONEFS_TRACE();
+
     struct hodo_datablock *buf_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
 
     if (buf_block == NULL) {
@@ -185,6 +197,7 @@ int read_all_dirents_from_direct_block(
     uint64_t *dirent_count
 ) {
     ZONEFS_TRACE();
+
     for (int j = HODO_DATA_START; j < HODO_DATABLOCK_SIZE - sizeof(struct hodo_dirent); j += sizeof(struct hodo_dirent)) {
         struct hodo_dirent temp_dirent;
         memcpy(&temp_dirent, (void*)direct_block + j, sizeof(struct hodo_dirent));
@@ -207,6 +220,8 @@ int read_all_dirents_from_indirect_block(
     struct dir_context *ctx,
     uint64_t *dirent_count
 ) {
+    ZONEFS_TRACE();
+
     struct hodo_block_pos temp_block_pos;
     struct hodo_datablock *temp_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
 
@@ -241,6 +256,17 @@ int read_all_dirents_from_indirect_block(
     return !END_READ;
 }
 
+static bool hodo_dir_emit(struct dir_context *ctx, struct hodo_dirent *temp_dirent){
+    return dir_emit(
+                    ctx,
+                    temp_dirent->name,
+                    temp_dirent->name_len,
+                    temp_dirent->i_ino,
+                    ((temp_dirent->file_type == HODO_TYPE_DIR) ? DT_DIR : DT_REG)
+    );
+}
+
+/*-------------------------------------------------------------create용 함수-------------------------------------------------------------------------------*/
 int add_dirent(struct inode* dir, struct hodo_inode* sub_inode) {
     ZONEFS_TRACE();
 
@@ -318,23 +344,10 @@ int add_dirent(struct inode* dir, struct hodo_inode* sub_inode) {
     return -1;
 }
 
-int compact_datablock(struct hodo_datablock *source_block, int remove_start_index, int remove_size, struct hodo_block_pos *out_pos){
-    struct hodo_datablock *temp_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
-    int remove_end_index = remove_start_index + remove_size;
-
-    //(0~remove_start_index) 사이의 내용을 temp_block으로 옮긴다
-    memcpy(temp_block, source_block, remove_start_index);
-    //(remove_end_index~HODO_DATABLOCK_SIZE) 사이의 내용을 temp_block 안에 덧붙인다.
-    memcpy((void*)temp_block + remove_start_index, (void*)source_block + remove_end_index, HODO_DATABLOCK_SIZE - remove_end_index);
-
-    hodo_write_struct(temp_block, sizeof(struct hodo_datablock), out_pos);
-    
-    kfree(temp_block);
-    return 0;
-}
-
+/*-------------------------------------------------------------unlink용 함수-------------------------------------------------------------------------------*/
 int remove_dirent(struct hodo_inode *dir_hodo_inode, struct inode *dir, const char *target_name, struct hodo_block_pos *out_pos){
     ZONEFS_TRACE();
+
     struct hodo_datablock *buf_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
 
     if (buf_block == NULL) {
@@ -408,6 +421,8 @@ int remove_dirent_from_direct_block(
     const char *target_name,
     struct hodo_block_pos *out_pos
 ) {
+    ZONEFS_TRACE();
+
     for (int j = HODO_DATA_START; j < HODO_DATABLOCK_SIZE - sizeof(struct hodo_dirent); j += sizeof(struct hodo_dirent)) {
         struct hodo_dirent temp_dirent;
         memcpy(&temp_dirent, (void*)direct_block + j, sizeof(struct hodo_dirent));
@@ -427,6 +442,8 @@ int remove_dirent_from_indirect_block(
     const char *target_name,
     struct hodo_block_pos *out_pos
 ) {
+    ZONEFS_TRACE();
+
     struct hodo_block_pos temp_block_pos;
     struct hodo_datablock *temp_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
 
@@ -466,26 +483,133 @@ int remove_dirent_from_indirect_block(
     return NOTHING_FOUND;
 }
 
-bool is_dirent_valid(struct hodo_dirent *dirent){
+/*-------------------------------------------------------------rmdir용 함수 선언--------------------------------------------------------------------------------*/
+bool check_directory_empty(struct dentry *dentry){
     ZONEFS_TRACE();
+    
+    //디렉토리가 루트 디록테리면 매핑 테이블에서 인덱스를 아이노드 번호가 아니라, 0번을 이용해야 하므로 루트 디렉토리인지를 확인한다.
+    uint64_t dir_mapping_index;
 
-    if(
-        dirent->name[0] != '\0' &&
-        dirent->name_len != 0 &&
-        dirent->i_ino != 0 &&
-        (dirent->file_type == HODO_TYPE_DIR ||
-        dirent->file_type == HODO_TYPE_REG)
-    )   
-        return true;
-    else
-        return false;
+    if(dentry->d_inode == dentry->d_sb->s_root->d_inode) {
+        dir_mapping_index = 0;
+    }
+    else {
+        dir_mapping_index = dentry->d_inode->i_ino - mapping_info.starting_ino;
+    }
+
+    //디렉토리의 hodo 아이노드를 저장장치로부터 읽어온다
+    struct hodo_block_pos dir_hodo_pos = mapping_info.mapping_table[dir_mapping_index];
+    struct hodo_inode dir_hodo_inode;
+    hodo_read_struct(dir_hodo_pos, &dir_hodo_inode, sizeof(struct hodo_inode));
+
+    //디렉토리 hodo 아이노드가 가리키는 데이터블록들을 순회할 준비를 한다
+    struct hodo_datablock *buf_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
+
+    if (buf_block == NULL) {
+        pr_info("zonefs: (error in hodo_sub_readdir) cannot allocate 4KB heap space for datablock variable\n");
+        return EMPTY_CHECKED;
+    }
+
+    int result;
+
+    //direct data block들이 비워져있는지 확인하기
+    struct hodo_block_pos direct_block_pos;
+
+    for (int i = 0; i < 10; i++) {
+        direct_block_pos = dir_hodo_inode.direct[i];
+        
+        if(is_block_pos_valid(direct_block_pos)) {
+
+            hodo_read_struct(direct_block_pos, buf_block, HODO_DATABLOCK_SIZE);
+
+            result = check_directory_empty_from_direct_block(buf_block);
+            
+            if(result != EMPTY_CHECKED) {
+                kfree(buf_block);
+                return result;
+            }
+        }
+    }
+
+    //single, double, triple indirect data block를 통해 간접적으로 가리키는 direct_data_block들이 비워져있는지 확인하기
+    struct hodo_block_pos indirect_block_pos[3] = {
+        dir_hodo_inode.single_indirect,
+        dir_hodo_inode.double_indirect,
+        dir_hodo_inode.triple_indirect
+    };
+
+    for(int i = 0; i < 3; i++){
+        if(is_block_pos_valid(indirect_block_pos[i])) {
+            hodo_read_struct(indirect_block_pos[i], buf_block, HODO_DATABLOCK_SIZE);
+
+            result = check_directory_empty_from_indirect_block(buf_block);
+
+            if(result != EMPTY_CHECKED) {
+                kfree(buf_block);
+                return result;
+            }
+        }
+    }
+
+    //모두 잘 다 뒤져보았으므로 더 읽을 필요가 없음을 알려주기 위해 END_READ를 반환하고 끝낸다
+    kfree(buf_block);
+    return EMPTY_CHECKED;
 }
 
-void hodo_set_bitmap(int i, int j) {
+bool check_directory_empty_from_direct_block(struct hodo_datablock *direct_block){
+    ZONEFS_TRACE();
+
+    const char zero[HODO_DATABLOCK_SIZE - HODO_DATA_START] = {0};
+
+    if(memcmp(direct_block->data, zero, HODO_DATABLOCK_SIZE - HODO_DATA_START) == 0)
+        return EMPTY_CHECKED;
+    else
+        return !EMPTY_CHECKED;
+}
+
+bool check_directory_empty_from_indirect_block(struct hodo_datablock *indirect_block){
+    ZONEFS_TRACE();
+
+    struct hodo_block_pos temp_block_pos;
+    struct hodo_datablock *temp_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
+
+    if (temp_block == NULL) {
+        pr_info("zonefs: (error in hodo_sub_lookup) cannot allocate 4KB heap space for datablock variable\n");
+        return EMPTY_CHECKED;
+    }
+
+    for (int j = HODO_DATA_START; j < HODO_DATABLOCK_SIZE - sizeof(struct hodo_block_pos); j += sizeof(struct hodo_block_pos)) {
+        memcpy(&temp_block_pos, (void*)indirect_block + j, sizeof(struct hodo_block_pos));
+
+        if(!is_block_pos_valid(temp_block_pos))
+            continue;
+
+        hodo_read_struct(temp_block_pos, temp_block, HODO_DATABLOCK_SIZE);
+
+        uint64_t result;
+
+        if(is_directblock(temp_block))
+            result = check_directory_empty_from_direct_block(temp_block);
+
+        else 
+            result = check_directory_empty_from_indirect_block(temp_block);
+
+        if (result != EMPTY_CHECKED){
+            kfree(temp_block);
+            return result;
+        }
+    }
+
+    kfree(temp_block);
+    return EMPTY_CHECKED;
+}
+
+/*-------------------------------------------------------------비트맵용 함수-------------------------------------------------------------------------------*/
+static void hodo_set_bitmap(int i, int j) {
     mapping_info.bitmap[i] |= (1 << (31 - j));
 }
 
-void hodo_unset_bitmap(int i, int j) {
+static void hodo_unset_bitmap(int i, int j) {
     mapping_info.bitmap[i] &= ~(1 << (31 - j));
 }
 
@@ -503,13 +627,13 @@ int hodo_get_next_ino(void) {
     return -1;
 }
 
-int hodo_erase_table_entry(int table_entry_index){
+int hodo_erase_table_entry(int table_entry_index) {
     hodo_unset_bitmap(table_entry_index/32, table_entry_index%32);
     return 0;
 }
 
-ssize_t hodo_read_struct(struct hodo_block_pos block_pos, void *out_buf, size_t len)
-{
+/*-------------------------------------------------------------입출력 함수-------------------------------------------------------------------------------*/
+ssize_t hodo_read_struct(struct hodo_block_pos block_pos, void *out_buf, size_t len) {
     ZONEFS_TRACE();
 
     uint32_t zone_id = block_pos.zone_id;
@@ -563,8 +687,7 @@ ssize_t hodo_read_struct(struct hodo_block_pos block_pos, void *out_buf, size_t 
     return ret;
 }
 
-ssize_t hodo_write_struct(void *buf, size_t len, struct hodo_block_pos *out_pos)
-{
+ssize_t hodo_write_struct(void *buf, size_t len, struct hodo_block_pos *out_pos) {
     ZONEFS_TRACE();
 
     uint32_t zone_id = mapping_info.wp.zone_id;
@@ -643,9 +766,22 @@ ssize_t hodo_write_struct(void *buf, size_t len, struct hodo_block_pos *out_pos)
     return ret;
 }
 
+ssize_t compact_datablock(struct hodo_datablock *source_block, int remove_start_index, int remove_size, struct hodo_block_pos *out_pos){
+    struct hodo_datablock *temp_block = kmalloc(HODO_DATABLOCK_SIZE, GFP_KERNEL);
+    int remove_end_index = remove_start_index + remove_size;
 
-ssize_t hodo_read_on_disk_mapping_info(void)
-{
+    //(0~remove_start_index) 사이의 내용을 temp_block으로 옮긴다
+    memcpy(temp_block, source_block, remove_start_index);
+    //(remove_end_index~HODO_DATABLOCK_SIZE) 사이의 내용을 temp_block 안에 덧붙인다.
+    memcpy((void*)temp_block + remove_start_index, (void*)source_block + remove_end_index, HODO_DATABLOCK_SIZE - remove_end_index);
+
+    ssize_t size = hodo_write_struct(temp_block, sizeof(struct hodo_datablock), out_pos);
+    
+    kfree(temp_block);
+    return size;
+}
+
+ssize_t hodo_read_on_disk_mapping_info(void) {
     ZONEFS_TRACE();
 
     uint32_t zone_id = 0;
@@ -693,6 +829,20 @@ ssize_t hodo_read_on_disk_mapping_info(void)
     return ret;
 }
 
+/*-------------------------------------------------------------도구 함수-------------------------------------------------------------------------------*/
+bool is_dirent_valid(struct hodo_dirent *dirent){
+    if(
+        dirent->name[0] != '\0' &&
+        dirent->name_len != 0 &&
+        dirent->i_ino != 0 &&
+        (dirent->file_type == HODO_TYPE_DIR ||
+        dirent->file_type == HODO_TYPE_REG)
+    )   
+        return true;
+    else
+        return false;
+}
+
 bool is_block_pos_valid(struct hodo_block_pos block_pos){
     if(block_pos.zone_id != 0) return true;
     else return false;
@@ -701,14 +851,4 @@ bool is_block_pos_valid(struct hodo_block_pos block_pos){
 bool is_directblock(struct hodo_datablock *datablock){
     if(datablock->magic[3] == '0') return true;
     else return false;
-}
-
-bool hodo_dir_emit(struct dir_context *ctx, struct hodo_dirent *temp_dirent){
-    return dir_emit(
-                    ctx,
-                    temp_dirent->name,
-                    temp_dirent->name_len,
-                    temp_dirent->i_ino,
-                    ((temp_dirent->file_type == HODO_TYPE_DIR) ? DT_DIR : DT_REG)
-    );
 }

--- a/trans.h
+++ b/trans.h
@@ -21,7 +21,7 @@ int read_all_dirents_from_direct_block(struct hodo_datablock* direct_block,struc
 int read_all_dirents_from_indirect_block(struct hodo_datablock* indirect_block, struct dir_context *ctx, uint64_t *dirent_count);
 
 int add_dirent(struct inode* dir, struct hodo_inode* sub_inode);
-int remove_dirent(struct hodo_inode *dir_hodo_inode, const char *target_name, struct hodo_block_pos *out_pos);
+int remove_dirent(struct hodo_inode *dir_hodo_inode, struct inode *dir, const char *target_name, struct hodo_block_pos *out_pos);
 int remove_dirent_from_direct_block(struct hodo_datablock *direct_block, const char *target_name, struct hodo_block_pos *out_pos);
 int remove_dirent_from_indirect_block(struct hodo_datablock *indirect_block, const char *target_name, struct hodo_block_pos *out_pos);
 bool is_dirent_valid(struct hodo_dirent *dirent);
@@ -29,8 +29,8 @@ bool is_dirent_valid(struct hodo_dirent *dirent);
 int hodo_get_next_ino(void);
 int hodo_erase_table_entry(int table_entry_index);
 
-ssize_t hodo_read_struct(struct hodo_block_pos block_pos, char *out_buf, size_t len);
-ssize_t hodo_write_struct(char *buf, size_t len, struct hodo_block_pos *out_pos);
+ssize_t hodo_read_struct(struct hodo_block_pos block_pos, void *out_buf, size_t len);
+ssize_t hodo_write_struct(void *buf, size_t len, struct hodo_block_pos *out_pos);
 ssize_t hodo_read_on_disk_mapping_info(void);
 
 bool is_block_pos_valid(struct hodo_block_pos block_pos);

--- a/trans.h
+++ b/trans.h
@@ -12,28 +12,42 @@
 #ifndef __TRANS_H__
 #define __TRANS_H__
 
+/*-------------------------------------------------------------lookup용 함수 선언-------------------------------------------------------------------------------*/
 uint64_t find_inode_number(struct hodo_inode *dir_hodo_inode, const char *target_name);
 uint64_t find_inode_number_from_direct_block(struct hodo_datablock *direct_block, const char *target_name);
 uint64_t find_inode_number_from_indirect_block(struct hodo_datablock *indirect_block, const char *target_name);
 
+/*-------------------------------------------------------------readdir용 함수 선언-------------------------------------------------------------------------------*/
 int read_all_dirents(struct hodo_inode *dir_hodo_inode, struct dir_context *ctx, uint64_t *dirent_count);
 int read_all_dirents_from_direct_block(struct hodo_datablock* direct_block,struct dir_context *ctx, uint64_t *dirent_count);
 int read_all_dirents_from_indirect_block(struct hodo_datablock* indirect_block, struct dir_context *ctx, uint64_t *dirent_count);
 
+/*-------------------------------------------------------------create용 함수 선언--------------------------------------------------------------------------------*/
 int add_dirent(struct inode* dir, struct hodo_inode* sub_inode);
+
+/*-------------------------------------------------------------unlink용 함수 선언--------------------------------------------------------------------------------*/
 int remove_dirent(struct hodo_inode *dir_hodo_inode, struct inode *dir, const char *target_name, struct hodo_block_pos *out_pos);
 int remove_dirent_from_direct_block(struct hodo_datablock *direct_block, const char *target_name, struct hodo_block_pos *out_pos);
 int remove_dirent_from_indirect_block(struct hodo_datablock *indirect_block, const char *target_name, struct hodo_block_pos *out_pos);
-bool is_dirent_valid(struct hodo_dirent *dirent);
 
+/*-------------------------------------------------------------rmdir용 함수 선언--------------------------------------------------------------------------------*/
+bool check_directory_empty(struct dentry *dentry);
+bool check_directory_empty_from_direct_block(struct hodo_datablock *direct_block);
+bool check_directory_empty_from_indirect_block(struct hodo_datablock *indirect_block);
+
+/*-------------------------------------------------------------비트맵용 함수 선언---------------------------------------------------------------------------------*/
 int hodo_get_next_ino(void);
 int hodo_erase_table_entry(int table_entry_index);
 
+/*-------------------------------------------------------------입출력 함수 선언-----------------------------------------------------------------------------------*/
 ssize_t hodo_read_struct(struct hodo_block_pos block_pos, void *out_buf, size_t len);
 ssize_t hodo_write_struct(void *buf, size_t len, struct hodo_block_pos *out_pos);
+ssize_t compact_datablock(struct hodo_datablock *source_block, int remove_start_index, int remove_size, struct hodo_block_pos *out_pos);
 ssize_t hodo_read_on_disk_mapping_info(void);
 
+/*-------------------------------------------------------------도구 함수 선언-------------------------------------------------------------------------------------*/
+bool is_dirent_valid(struct hodo_dirent *dirent);
 bool is_block_pos_valid(struct hodo_block_pos block_pos);
 bool is_directblock(struct hodo_datablock *datablock);
-bool hodo_dir_emit(struct dir_context *ctx, struct hodo_dirent *temp_dirent);
+
 #endif

--- a/trans.h
+++ b/trans.h
@@ -12,21 +12,25 @@
 #ifndef __TRANS_H__
 #define __TRANS_H__
 
-uint64_t find_inode_number(struct hodo_inode *parent_hodo_inode, const char *target_name);
-uint64_t find_inode_number_from_direct_block(const char *target_name, struct hodo_datablock *direct_block);
-uint64_t find_inode_number_from_indirect_block(const char *target_name,struct hodo_datablock *indirect_block);
+uint64_t find_inode_number(struct hodo_inode *dir_hodo_inode, const char *target_name);
+uint64_t find_inode_number_from_direct_block(struct hodo_datablock *direct_block, const char *target_name);
+uint64_t find_inode_number_from_indirect_block(struct hodo_datablock *indirect_block, const char *target_name);
 
 int read_all_dirents(struct hodo_inode *dir_hodo_inode, struct dir_context *ctx, uint64_t *dirent_count);
 int read_all_dirents_from_direct_block(struct hodo_datablock* direct_block,struct dir_context *ctx, uint64_t *dirent_count);
 int read_all_dirents_from_indirect_block(struct hodo_datablock* indirect_block, struct dir_context *ctx, uint64_t *dirent_count);
 
 int add_dirent(struct inode* dir, struct hodo_inode* sub_inode);
-
+int remove_dirent(struct hodo_inode *dir_hodo_inode, const char *target_name, struct hodo_block_pos *out_pos);
+int remove_dirent_from_direct_block(struct hodo_datablock *direct_block, const char *target_name, struct hodo_block_pos *out_pos);
+int remove_dirent_from_indirect_block(struct hodo_datablock *indirect_block, const char *target_name, struct hodo_block_pos *out_pos);
 bool is_dirent_valid(struct hodo_dirent *dirent);
+
 int hodo_get_next_ino(void);
+int hodo_erase_table_entry(int table_entry_index);
 
 ssize_t hodo_read_struct(struct hodo_block_pos block_pos, char *out_buf, size_t len);
-ssize_t hodo_write_struct(char *buf, size_t len);
+ssize_t hodo_write_struct(char *buf, size_t len, struct hodo_block_pos *out_pos);
 ssize_t hodo_read_on_disk_mapping_info(void);
 
 bool is_block_pos_valid(struct hodo_block_pos block_pos);


### PR DESCRIPTION
[what]
-파일 및 디렉토리의 생성 및 삭제, 그리고 동일 명의 파일 및 디렉토리의 재생성에도 문제가 없음을 확인함.
-예하 파일이 있는 경우 해당 디렉토리는 삭제 못하도록 하는 기능도 확인함.
-파일 삭제가 일어난 디렉토리의 i_size 감소, 변경 시간 업데이트 등도 작성함.
-다만 아직 불특정 시점에 가상 머신이 멈추는 오류의 빈도가 다소 증가한 것 같음.

[how]
-rm 기능은 unlink(..) 함수와 예하 remove_dirent(..) 함수를 통해 구현함.
-위 함수들에 추가된 주요 로직은, 부모 디렉토리에 저장된 삭제 대상 파일의 dirent를 지우며 데이터 블록들이 거슬러 올라가며 아이노드까지 새로 써지는 로직임.
-이를 위해 struct hodo_block_pos *out_pos라는 출력용 매개변수를 두어서 데이터 블록이 새로 쓰여진 위치를 부모에게 반환할 수 있도록 함.
-또한 이를 위해 hodo_write_struct(..)에도 동일한 매개변수를 추가함. 굳이 출력용 매개변수인 out_pos를 사용하지 않는 기존 경우들을 위해, 이 매개변수에 인자로 NULL을 주면 기존처럼 사용 가능하도록 하였고, 이에 맞춰 기존 코드들을 수정함.
-rmdir은 말 그대로 rmdir(..)함수와 예하 check_directory_empty(..) 함수를 통해 구현함.
-rmdir(..) 함수는 unlink(..)함수를 하위 함수로 사용하여서 구현하였다. 다만 비어있지 않은 디렉토리는 삭제하면 안되므로 이를 확인하도록 함.

[etc]
-read_struct(..), write_struct(..)를 사용할 때 인자에 붙히던 (char*) 캐스팅이 거슬려서, read_struct(..)와 write_struct(..)의 버퍼 매개변수 타입을 void*로 변경했음.
-hodo.h hodo.c trans.h trans.c 파일들의 함수들을 보기 좋게 정리함.

[ex. rm 기능 구동]
<img width="471" height="1059" alt="스크린샷 2025-08-06 204501" src="https://github.com/user-attachments/assets/b5a32120-9f06-499b-b682-702c011ddfc2" />

[ex. rmdir 기능 구동]
<img width="637" height="743" alt="스크린샷 2025-08-07 020143" src="https://github.com/user-attachments/assets/63422a8d-a990-4797-be9e-9a44336498dc" />