### PR TITLE
write_iter에서 indirect block 지원 기능 구현

### DIFF
--- a/hodo.c
+++ b/hodo.c
@@ -17,7 +17,9 @@
 #include "hodo.h"
 #include "trans.h"
 /*----------------------------------------------------------파일 오퍼레이션 함수 선언----------------------------------------------------------------------------------*/
-//nothing
+static ssize_t hodo_file_read_iter(struct kiocb *iocb, struct iov_iter *to);
+static ssize_t hodo_file_write_iter(struct kiocb *iocb, struct iov_iter *from);
+static int hodo_readdir(struct file *file, struct dir_context *ctx);
 
 /*----------------------------------------------------------아이노드 오퍼레이션 함수 선언-------------------------------------------------------------------------------*/
 static int hodo_setattr(struct mnt_idmap *idmap, struct dentry *dentry, struct iattr *iattr);

--- a/trans.h
+++ b/trans.h
@@ -14,6 +14,12 @@
 
 /*-----------------------------------------------------------read_iter용 함수 선언------------------------------------------------------------------------------*/
 void  hodo_read_nth_block(struct hodo_inode *file_inode, int n, struct hodo_datablock *dst_datablock);
+
+/*-------------------------------------------------------------write_iter용 함수 선언----------------------------------------------------------------------------*/
+ssize_t write_target(struct kiocb *iocb, struct iov_iter *from);
+ssize_t write_target_to_direct_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *current_direct_block);
+ssize_t write_target_to_indirect_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *current_indirect_block);
+
 /*-------------------------------------------------------------lookup용 함수 선언-------------------------------------------------------------------------------*/
 uint64_t find_inode_number(struct hodo_inode *dir_hodo_inode, const char *target_name);
 uint64_t find_inode_number_from_direct_block(struct hodo_datablock *direct_block, const char *target_name);
@@ -36,11 +42,6 @@ int remove_dirent_from_indirect_block(struct hodo_datablock *indirect_block, con
 bool check_directory_empty(struct dentry *dentry);
 bool check_directory_empty_from_direct_block(struct hodo_datablock *direct_block);
 bool check_directory_empty_from_indirect_block(struct hodo_datablock *indirect_block);
-
-/*-------------------------------------------------------------write_iter용 함수 선언----------------------------------------------------------------------------*/
-ssize_t write_target(struct kiocb *iocb, struct iov_iter *from);
-ssize_t write_target_to_direct_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *left_over);
-ssize_t write_target_to_indirect_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *block_poses);
 
 /*-------------------------------------------------------------비트맵용 함수 선언---------------------------------------------------------------------------------*/
 int hodo_get_next_ino(void);


### PR DESCRIPTION
(what)
-hodo_inode에서 가리키는 direct_data_block 10개 말고, single_indirect_data_block ~ triple_indirect_data_block을 통한 쓰기 연산을 기능을 추가 구현함. -direct_data_block에 쓸 수 있는 크기(4096 B * 10 = 40960 B)를 넘어서는 dd 쓰기 명령을 확인해본 결과 정상적으로 쓰임. 40 MB의 파일을 쓰는데 대략 7초가 걸렸음(5.5MB/S) -다만 워낙 용량이 커져서인지 cat을 통해 read를 확인해보려고 하니 죽는 경우가 생겨 read의 경우 확인을 정확히 하지 못했음.

(how)
-기존에 작성하던 코드 구조를 최대한 참고하기 위해 마찬가지로 재귀 형식으로 작성함. 물론 아무리 호출해도 깊이가 4를 넘지는 않으니 스택이 터지지 않음.

[이미지 : 40960 Byte 난수 쓰기 성공]
<img width="854" height="414" alt="스크린샷 2025-08-21 103529" src="https://github.com/user-attachments/assets/2c342d52-4c17-49c7-9d6d-cac939ca9105" />

[이미지 : 위 난수를 cat으로 읽은 것] 
<img width="1235" height="727" alt="스크린샷 2025-08-21 103554" src="https://github.com/user-attachments/assets/12f9d0dd-6fc8-4712-b1d3-498937fc0c49" />

[이미지 :  약 40 MB zero 쓰기도 성공]
<img width="932" height="387" alt="스크린샷 2025-08-21 103959" src="https://github.com/user-attachments/assets/65b197d0-4bb2-4834-a371-e4af1220b0e2" />

