### PR TITLE
write_iter에서 short write로 인한 비효율 해결

### DIFF
--- a/hodo.c
+++ b/hodo.c
@@ -799,5 +799,18 @@ static int hodo_sub_setattr(struct mnt_idmap *idmap, struct dentry *dentry, stru
 static ssize_t hodo_sub_file_write_iter(struct kiocb *iocb, struct iov_iter *from){
     ZONEFS_TRACE();
     
-    return write_target(iocb, from);
+    uint64_t len = iov_iter_count(from);
+    ssize_t total_written_size = 0;
+    ssize_t temp_written_size = 0;
+
+    while(total_written_size < len){
+        temp_written_size =  write_one_block(iocb, from);
+
+        if(temp_written_size < 0)
+            return temp_written_size;
+        else
+            total_written_size += temp_written_size;
+    }
+    
+    return total_written_size;
 }

--- a/trans.h
+++ b/trans.h
@@ -16,9 +16,9 @@
 void  hodo_read_nth_block(struct hodo_inode *file_inode, int n, struct hodo_datablock *dst_datablock);
 
 /*-------------------------------------------------------------write_iter용 함수 선언----------------------------------------------------------------------------*/
-ssize_t write_target(struct kiocb *iocb, struct iov_iter *from);
-ssize_t write_target_to_direct_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *current_direct_block);
-ssize_t write_target_to_indirect_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *current_indirect_block);
+ssize_t write_one_block(struct kiocb *iocb, struct iov_iter *from);
+ssize_t write_one_block_by_direct_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *current_direct_block);
+ssize_t write_one_block_by_indirect_block(struct kiocb *iocb, struct iov_iter *from, struct hodo_block_pos *out_pos, struct hodo_datablock *current_indirect_block);
 
 /*-------------------------------------------------------------lookup용 함수 선언-------------------------------------------------------------------------------*/
 uint64_t find_inode_number(struct hodo_inode *dir_hodo_inode, const char *target_name);


### PR DESCRIPTION
(why)
fio 파일 쓰기 테스트 결과, bs=4092로 우리의 데이터블록내 데이터 영역 크기에 맞춰서 쓰기 명령을 테스트하면 비교적 효율적인 쓰기가 가능하나, 이보다 큰 bs 사이즈(ex: 4K)로 fio 테스트를 진행하면 4092만 쓰이고 반환되는 short write가 다량 발생해서 write_iter을 사용자 측에서 재호출해줘야하는 비효율적인 루틴이 발견됨.

(how)
hodo_sub_file_write_iter(..)에 반복문을 사용해서, VFS가 쓰기 요청한 길이를 모두 쓰고 반환되도록 함. 물론 write_one_block(..)에서 아예 인접한 블럭을 이어서 쓸 수 있는 로직을 추가로 제공하면 더 최적화할 수 있으리라 생각하지만, 일단은 냅두기로 함.

[이미지 : 파일 1MB 순차 쓰기 fio 테스트(short write 없이 성공)] 
<img width="1885" height="1082" alt="스크린샷 2025-08-23 142217" src="https://github.com/user-attachments/assets/c1c0fb56-c6ed-4dd0-adc5-d029790ca842" />

[이미지 : 파일 200MB 순차 쓰기 fio 테스트(short write 없이 성공)]
<img width="1377" height="909" alt="스크린샷 2025-08-23 142609" src="https://github.com/user-attachments/assets/9ead8173-1f4f-4b82-a952-2c3a77278a5a" />
